### PR TITLE
Update runtime to 49

### DIFF
--- a/io.github.kelvinnovais.Kasasa.json
+++ b/io.github.kelvinnovais.Kasasa.json
@@ -1,7 +1,7 @@
 {
     "id" : "io.github.kelvinnovais.Kasasa",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "48",
+    "runtime-version" : "49",
     "sdk" : "org.gnome.Sdk",
     "command" : "kasasa",
     "finish-args" : [
@@ -43,41 +43,6 @@
                     "type" : "git",
                     "url" : "https://github.com/flatpak/libportal.git",
                     "tag" : "0.9.1"
-                }
-            ]
-        },
-        {
-            "name" : "gst",
-            "buildsystem" : "meson",
-            "builddir" : true,
-            "config-opts" : [
-                "-Dbase=enabled",
-                "-Dgood=disabled",
-                "-Dugly=disabled",
-                "-Dbad=disabled",
-                "-Dlibav=disabled",
-                "-Ddevtools=disabled",
-                "-Dges=disabled",
-                "-Drtsp_server=disabled",
-                "-Drs=disabled",
-                "-Dgst-examples=disabled",
-                "-Dpython=disabled",
-                "-Dtls=disabled",
-                "-Dlibnice=disabled",
-                "-Dgpl=disabled",
-                "-Dqt5=disabled",
-                "-Dqt6=disabled",
-                "-Dwebrtc=disabled",
-                "-Dtests=disabled",
-                "-Dexamples=disabled",
-                "-Ddoc=disabled"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://gitlab.freedesktop.org/gstreamer/gstreamer.git",
-                    "tag" : "1.27.2",
-                    "disable-submodules" : true
                 }
             ]
         },


### PR DESCRIPTION
- Update runtime to 49
- Drop GStreamer modules which is alreday provided by the runtime

Fixes: https://github.com/flathub/io.github.kelvinnovais.Kasasa/issues/13